### PR TITLE
Reinforcement world whitelist support

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/citadel/Citadel.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/Citadel.java
@@ -109,7 +109,14 @@ public class Citadel extends ACivMod {
 			return;
 		}
 		typeManager = new ReinforcementTypeManager();
-		config.getReinforcementTypes().forEach(t -> typeManager.register(t));
+		config.getReinforcementTypes().forEach(t ->
+		{
+			if (!typeManager.register(t)) {
+				logger.severe("Errors in the config file, shutting down");
+				Bukkit.shutdown();
+				return;
+			}
+		});
 		dao = new CitadelDAO(this.logger, config.getDatabase());
 		if (!dao.updateDatabase()) {
 			logger.severe("Errors setting up database, shutting down");

--- a/paper/src/main/java/vg/civcraft/mc/citadel/CitadelConfigManager.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/CitadelConfigManager.java
@@ -3,6 +3,8 @@ package vg.civcraft.mc.citadel;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.configuration.ConfigurationSection;
@@ -162,6 +164,7 @@ public class CitadelConfigManager extends ConfigParser {
 		double decayMultiplier = config.getDouble("decay_multiplier", globalDecayMultiplier);
 		double multiplerOnDeletedGroup = config.getDouble("deleted_group_multipler", 4);
 		int legacyId = config.getInt("legacy_id", -1);
+		List<String> allowedWorlds = ConfigHelper.getStringList(config, "allowed_worlds");
 		if (name == null) {
 			logger.warning("No name specified for reinforcement type at " + config.getCurrentPath());
 			name = item.getType().name();
@@ -175,13 +178,14 @@ public class CitadelConfigManager extends ConfigParser {
 					+ ". This does not make sense and the type will be ignored");
 			return null;
 		}
+		//TODO Should really be replaced with a toString() method
 		logger.info("Parsed reinforcement type " + name + " for item " + item.toString() + ", returnChance: "
 				+ returnChance + ", maturationTime: " + TextUtil.formatDuration(maturationTime, TimeUnit.MILLISECONDS)
 				+ ", acidTime: " + TextUtil.formatDuration(acidTime, TimeUnit.MILLISECONDS) + ", gracePeriod: "
-				+ gracePeriod + ", id: " + id);
+				+ gracePeriod + ", id: " + id + ", allowedWorlds: " + StringUtils.join(allowedWorlds, ", "));
 		return new ReinforcementType(health, returnChance, item, maturationTime, acidTime, acidPriority, maturationScale, gracePeriod,
 				creationEffect, damageEffect, destructionEffect, reinforceables, nonReinforceables, id, name,
-				globalBlackList, decayTimer, decayMultiplier, multiplerOnDeletedGroup, legacyId);
+				globalBlackList, decayTimer, decayMultiplier, multiplerOnDeletedGroup, legacyId, allowedWorlds);
 	}
 
 	private void parseReinforcementTypes(ConfigurationSection config) {

--- a/paper/src/main/java/vg/civcraft/mc/citadel/CitadelUtility.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/CitadelUtility.java
@@ -162,6 +162,13 @@ public class CitadelUtility {
 					block.getLocation());
 			return true;
 		}
+		// check if reinforcement is allowed in the current world
+		if (!type.isAllowedInWorld(block.getWorld().getName()))
+		{
+			CitadelUtility.sendAndLog(player, ChatColor.RED,
+					type.getName() + " can not reinforce in this dimension", block.getLocation());
+			return true;
+		}
 		ItemMap playerItems = new ItemMap(player.getInventory());
 		if (player.getInventory().getItemInOffHand() != null) {
 			playerItems.addItemStack(player.getInventory().getItemInOffHand());

--- a/paper/src/main/java/vg/civcraft/mc/citadel/command/AdvancedFortification.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/command/AdvancedFortification.java
@@ -49,7 +49,7 @@ public class AdvancedFortification extends BaseCommand {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You need to hold a reinforcement item in your off hand");
 			return;
 		}
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(offHand);
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(offHand, player.getWorld().getName());
 		if (type == null) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You can not reinforce with the item in your off hand");
 			return;

--- a/paper/src/main/java/vg/civcraft/mc/citadel/command/AdvancedFortification.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/command/AdvancedFortification.java
@@ -49,7 +49,7 @@ public class AdvancedFortification extends BaseCommand {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You need to hold a reinforcement item in your off hand");
 			return;
 		}
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(offHand);
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStackAndWorld(offHand, player.getWorld().getName());
 		if (type == null) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You can not reinforce with the item in your off hand");
 			return;

--- a/paper/src/main/java/vg/civcraft/mc/citadel/command/AdvancedFortification.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/command/AdvancedFortification.java
@@ -49,7 +49,7 @@ public class AdvancedFortification extends BaseCommand {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You need to hold a reinforcement item in your off hand");
 			return;
 		}
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStackAndWorld(offHand, player.getWorld().getName());
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(offHand);
 		if (type == null) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You can not reinforce with the item in your off hand");
 			return;

--- a/paper/src/main/java/vg/civcraft/mc/citadel/command/AreaReinforce.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/command/AreaReinforce.java
@@ -28,7 +28,7 @@ public class AreaReinforce extends BaseCommand {
 	public void execute(Player p, @Optional String targetGroup, String minX, String minY, String minZ, String maxX, String maxY, String maxZ) {
 		UUID uuid = NameAPI.getUUID(p.getName());
 		ReinforcementType reinType = Citadel.getInstance().getReinforcementTypeManager()
-				.getByItemStack(p.getInventory().getItemInMainHand());
+				.getByItemStack(p.getInventory().getItemInMainHand(), p.getWorld().getName());
 		if (reinType == null) {
 			CitadelUtility.sendAndLog(p, ChatColor.RED, "The item you are holding is not a possible reinforcement");
 			return;

--- a/paper/src/main/java/vg/civcraft/mc/citadel/command/AreaReinforce.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/command/AreaReinforce.java
@@ -28,7 +28,7 @@ public class AreaReinforce extends BaseCommand {
 	public void execute(Player p, @Optional String targetGroup, String minX, String minY, String minZ, String maxX, String maxY, String maxZ) {
 		UUID uuid = NameAPI.getUUID(p.getName());
 		ReinforcementType reinType = Citadel.getInstance().getReinforcementTypeManager()
-				.getByItemStackAndWorld(p.getInventory().getItemInMainHand(), p.getWorld().getName());
+				.getByItemStack(p.getInventory().getItemInMainHand());
 		if (reinType == null) {
 			CitadelUtility.sendAndLog(p, ChatColor.RED, "The item you are holding is not a possible reinforcement");
 			return;

--- a/paper/src/main/java/vg/civcraft/mc/citadel/command/AreaReinforce.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/command/AreaReinforce.java
@@ -28,7 +28,7 @@ public class AreaReinforce extends BaseCommand {
 	public void execute(Player p, @Optional String targetGroup, String minX, String minY, String minZ, String maxX, String maxY, String maxZ) {
 		UUID uuid = NameAPI.getUUID(p.getName());
 		ReinforcementType reinType = Citadel.getInstance().getReinforcementTypeManager()
-				.getByItemStack(p.getInventory().getItemInMainHand());
+				.getByItemStackAndWorld(p.getInventory().getItemInMainHand(), p.getWorld().getName());
 		if (reinType == null) {
 			CitadelUtility.sendAndLog(p, ChatColor.RED, "The item you are holding is not a possible reinforcement");
 			return;

--- a/paper/src/main/java/vg/civcraft/mc/citadel/command/Fortification.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/command/Fortification.java
@@ -33,7 +33,7 @@ public class Fortification extends BaseCommand {
 			return;
 		}
 		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager()
-				.getByItemStackAndWorld(player.getInventory().getItemInMainHand(), player.getWorld().getName());
+				.getByItemStack(player.getInventory().getItemInMainHand());
 		if (type == null) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You can not reinforce with this item");
 			stateManager.setState(player, null);

--- a/paper/src/main/java/vg/civcraft/mc/citadel/command/Fortification.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/command/Fortification.java
@@ -33,7 +33,7 @@ public class Fortification extends BaseCommand {
 			return;
 		}
 		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager()
-				.getByItemStack(player.getInventory().getItemInMainHand());
+				.getByItemStackAndWorld(player.getInventory().getItemInMainHand(), player.getWorld().getName());
 		if (type == null) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You can not reinforce with this item");
 			stateManager.setState(player, null);

--- a/paper/src/main/java/vg/civcraft/mc/citadel/command/Fortification.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/command/Fortification.java
@@ -33,7 +33,7 @@ public class Fortification extends BaseCommand {
 			return;
 		}
 		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager()
-				.getByItemStack(player.getInventory().getItemInMainHand());
+				.getByItemStack(player.getInventory().getItemInMainHand(), player.getWorld().getName());
 		if (type == null) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You can not reinforce with this item");
 			stateManager.setState(player, null);

--- a/paper/src/main/java/vg/civcraft/mc/citadel/command/ReinforcementsGUI.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/command/ReinforcementsGUI.java
@@ -7,8 +7,13 @@ import java.text.DecimalFormat;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import vg.civcraft.mc.citadel.Citadel;
@@ -19,6 +24,8 @@ import vg.civcraft.mc.civmodcore.inventory.gui.MultiPageView;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.utilities.TextUtil;
 
+import static java.util.stream.Collectors.partitioningBy;
+
 public class ReinforcementsGUI extends BaseCommand {
 
 	private DecimalFormat format = new DecimalFormat("##.##");
@@ -26,14 +33,39 @@ public class ReinforcementsGUI extends BaseCommand {
 	@CommandAlias("ctdl|reinforcements")
 	@Description("Opens a GUI displaying all reinforcement materials")
 	public void execute(Player sender) {
-		List<ReinforcementType> types = new LinkedList<>(
-				Citadel.getInstance().getReinforcementTypeManager().getAllTypes());
+
+		Map<Boolean, List<ReinforcementType>> allowedOrNot = Citadel.getInstance().getReinforcementTypeManager().getAllTypes()
+				.stream().collect(partitioningBy(i ->
+						i.isAllowedInWorld(sender.getWorld().getName())));
+
+		List<ReinforcementType> allowedTypes = allowedOrNot.get(true);
+		List<ReinforcementType> disallowedTypes = allowedOrNot.get(false);
+
 		// sort ascending by health
-		Collections.sort(types, (o1, o2) -> Double.compare(o1.getHealth(), o2.getHealth()));
+		Collections.sort(allowedTypes, (o1, o2) -> Double.compare(o1.getHealth(), o2.getHealth()));
+		Collections.sort(disallowedTypes, (o1, o2) -> Double.compare(o1.getHealth(), o2.getHealth()));
 		List<IClickable> clicks = new LinkedList<>();
+
+		clicks.addAll(getClicks(allowedTypes, true));
+
+		if (disallowedTypes.size() > 0) {
+			for (int i = 0; i < 18 - (allowedTypes.size() % 9); i++) {
+				clicks.add(new DecorationStack(Material.AIR));
+			}
+		}
+		clicks.addAll(getClicks(disallowedTypes, false));
+
+		MultiPageView pageView = new MultiPageView(sender, clicks, ChatColor.BLUE + "Reinforcements", true);
+		pageView.showScreen();
+	}
+
+	private List<IClickable> getClicks(List<ReinforcementType> types, boolean allowed)
+	{
+		List<IClickable> clickables = new LinkedList<>();
+
 		for (ReinforcementType type : types) {
 			ItemStack is = type.getItem().clone();
-			ItemUtils.setDisplayName(is, ChatColor.AQUA + type.getName());
+			ItemUtils.setComponentDisplayName(is, Component.text(ChatColor.AQUA + type.getName() + (allowed ? ChatColor.GREEN + " (Allowed in current dimension)" : ChatColor.RED + " (Not allowed in current dimension)")));
 			ItemUtils.addLore(is, ChatColor.GREEN + "Health: " + format.format(type.getHealth()));
 			ItemUtils.addLore(is, ChatColor.GOLD + "Maturation time: "
 					+ TextUtil.formatDuration(type.getMaturationTime(), TimeUnit.MILLISECONDS));
@@ -45,10 +77,20 @@ public class ReinforcementsGUI extends BaseCommand {
 			}
 			ItemUtils.addLore(is,
 					ChatColor.WHITE + "Return chance: " + format.format(type.getReturnChance() * 100.0) + " %");
+
+			ItemUtils.addComponentLore(is, Component.text(ChatColor.GOLD + "Allowed dimensions:"));
+			List<Component> allowedDimensionComponents = type.getAllowedWorlds().stream().map(e ->
+					Component.text(ChatColor.GREEN + " - " + e)).collect(Collectors.toList());
+
+			if (allowedDimensionComponents.isEmpty()) {
+				ItemUtils.addComponentLore(is, Component.text(ChatColor.DARK_GREEN + " * Everywhere"));
+			} else {
+				ItemUtils.addComponentLore(is, allowedDimensionComponents);
+			}
 			IClickable click = new DecorationStack(is);
-			clicks.add(click);
+			clickables.add(click);
 		}
-		MultiPageView pageView = new MultiPageView(sender, clicks, ChatColor.BLUE + "Reinforcements", true);
-		pageView.showScreen();
+
+		return clickables;
 	}
 }

--- a/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/NormalState.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/NormalState.java
@@ -31,7 +31,7 @@ public class NormalState extends AbstractPlayerState {
 			return;
 		}
 		ItemStack offHand = player.getInventory().getItemInOffHand();
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStackAndWorld(offHand, player.getWorld().getName());
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(offHand);
 		if (type == null) {
 			return;
 		}
@@ -53,7 +53,7 @@ public class NormalState extends AbstractPlayerState {
 			return;
 		}
 		ItemStack hand = player.getInventory().getItemInMainHand();
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStackAndWorld(hand, player.getWorld().getName());
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(hand);
 		if (type == null) {
 			return;
 		}

--- a/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/NormalState.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/NormalState.java
@@ -31,7 +31,7 @@ public class NormalState extends AbstractPlayerState {
 			return;
 		}
 		ItemStack offHand = player.getInventory().getItemInOffHand();
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(offHand);
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(offHand, player.getWorld().getName());
 		if (type == null) {
 			return;
 		}
@@ -53,7 +53,7 @@ public class NormalState extends AbstractPlayerState {
 			return;
 		}
 		ItemStack hand = player.getInventory().getItemInMainHand();
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(hand);
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(hand, player.getWorld().getName());
 		if (type == null) {
 			return;
 		}

--- a/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/NormalState.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/NormalState.java
@@ -31,7 +31,7 @@ public class NormalState extends AbstractPlayerState {
 			return;
 		}
 		ItemStack offHand = player.getInventory().getItemInOffHand();
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(offHand);
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStackAndWorld(offHand, player.getWorld().getName());
 		if (type == null) {
 			return;
 		}
@@ -53,7 +53,7 @@ public class NormalState extends AbstractPlayerState {
 			return;
 		}
 		ItemStack hand = player.getInventory().getItemInMainHand();
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(hand);
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStackAndWorld(hand, player.getWorld().getName());
 		if (type == null) {
 			return;
 		}

--- a/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/ReinforcingState.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/ReinforcingState.java
@@ -58,7 +58,7 @@ public class ReinforcingState extends AbstractPlayerState {
 					e.getClickedBlock().getLocation());
 			return;
 		}
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStackAndWorld(e.getItem(), player.getWorld().getName());
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(e.getItem());
 		// is it a valid item to reinforce with
 		if (type == null) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You can not reinforce with this item",

--- a/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/ReinforcingState.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/ReinforcingState.java
@@ -58,7 +58,7 @@ public class ReinforcingState extends AbstractPlayerState {
 					e.getClickedBlock().getLocation());
 			return;
 		}
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(e.getItem());
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(e.getItem(), player.getWorld().getName());
 		// is it a valid item to reinforce with
 		if (type == null) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You can not reinforce with this item",

--- a/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/ReinforcingState.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/ReinforcingState.java
@@ -73,6 +73,12 @@ public class ReinforcingState extends AbstractPlayerState {
 					block.getLocation());
 			return;
 		}
+		// is the reinforcement item allowed in the current world
+		if (!type.isAllowedInWorld(block.getWorld().getName())) {
+			CitadelUtility.sendAndLog(player, ChatColor.RED,
+					type.getName() + " cannot reinforce in this dimension", block.getLocation());
+			return;
+		}
 		// does the player have permission to reinforce on that group
 		if (!NameAPI.getGroupManager().hasAccess(group, e.getPlayer().getUniqueId(),
 				CitadelPermissionHandler.getReinforce())) {

--- a/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/ReinforcingState.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/ReinforcingState.java
@@ -58,7 +58,7 @@ public class ReinforcingState extends AbstractPlayerState {
 					e.getClickedBlock().getLocation());
 			return;
 		}
-		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(e.getItem());
+		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStackAndWorld(e.getItem(), player.getWorld().getName());
 		// is it a valid item to reinforce with
 		if (type == null) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED, "You can not reinforce with this item",

--- a/paper/src/main/java/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementType.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementType.java
@@ -28,12 +28,13 @@ public class ReinforcementType {
 	private double decayMultiplier;
 	private double deletedGroupMulitplier;
 	private int legacyId;
+	private Set<String> allowedWorlds;
 
 	public ReinforcementType(float health, double returnChance, ItemStack item, long maturationTime, long acidTime, int acidPriority,
 			double scale, long gracePeriod, ReinforcementEffect creationEffect, ReinforcementEffect damageEffect,
 			ReinforcementEffect destructionEffect, Collection<Material> allowsReinforceables,
 			Collection<Material> disallowedReinforceables, short id, String name, Collection<Material> globalBlackList,
-			long decayTimer, double decayMultiplier, double deletedGroupMulitplier, int legacyId) {
+			long decayTimer, double decayMultiplier, double deletedGroupMulitplier, int legacyId, Collection allowedWorlds) {
 		this.health = health;
 		this.name = name;
 		this.returnChance = returnChance;
@@ -59,6 +60,11 @@ public class ReinforcementType {
 		if (!globalBlackList.isEmpty()) {
 			this.globalBlackList.addAll(globalBlackList);
 		}
+		this.allowedWorlds = new TreeSet<>();
+		if (!allowedWorlds.isEmpty())
+		{
+			this.allowedWorlds.addAll(allowedWorlds);
+		}
 		this.id = id;
 		this.decayMultiplier = decayMultiplier;
 		this.decayTimer = decayTimer;
@@ -73,6 +79,21 @@ public class ReinforcementType {
 			return disallowedReinforceables == null || !disallowedReinforceables.contains(mat);
 		}
 		return allowedReinforceables.contains(mat);
+	}
+
+	public Set<String> getAllowedWorlds()
+	{
+		return allowedWorlds;
+	}
+
+	public boolean isAllowedInWorld(String worldName)
+	{
+		if (allowedWorlds.contains(worldName) || allowedWorlds.isEmpty())
+		{
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/paper/src/main/java/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementTypeManager.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementTypeManager.java
@@ -59,6 +59,11 @@ public class ReinforcementTypeManager {
 				return false;
 			}
 
+			if (globalTypesByItem.put(type.getItem(), type) != null) {
+				// Problem because there is already a global reinforcement for the item type registered
+				return false;
+			}
+
 			globalTypesByItem.put(type.getItem(), type); // Types with no allowed worlds are global and able to be used everywhere
 
 			return true;

--- a/paper/src/main/java/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementTypeManager.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementTypeManager.java
@@ -3,16 +3,19 @@ package vg.civcraft.mc.citadel.reinforcementtypes;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import org.bukkit.inventory.ItemStack;
 
 public class ReinforcementTypeManager {
 
-	private Map<ItemStack, ReinforcementType> typesByItem;
+	private Map<ItemStack, ReinforcementType> globalTypesByItem;
+	private Map<ItemStack, Map<String, ReinforcementType>> localTypesByItem;
 	private Map<Short, ReinforcementType> typesById;
 
 	public ReinforcementTypeManager() {
-		typesByItem = new HashMap<>();
+		globalTypesByItem = new HashMap<>();
+		localTypesByItem = new HashMap<>();
 		typesById = new TreeMap<>();
 	}
 
@@ -24,15 +27,59 @@ public class ReinforcementTypeManager {
 		return typesById.get(id);
 	}
 
-	public ReinforcementType getByItemStack(ItemStack is) {
+	public ReinforcementType getByItemStack(ItemStack is, String worldName) {
 		ItemStack copy = is.clone();
 		copy.setAmount(1);
-		return typesByItem.get(copy);
+
+		ReinforcementType foundType = globalTypesByItem.get(copy);
+
+		if (foundType == null) { // Reinforcement type is not global, aka local
+			if (localTypesByItem.get(copy) == null) { // The item type is not registered at all, so it can't have any allowed worlds
+				return null;
+			}
+
+			foundType = localTypesByItem.get(copy).get(worldName);
+
+			if (foundType == null) {
+				foundType = localTypesByItem.get(copy).values().stream().filter(Objects::nonNull).findAny().orElse(null);
+			}
+
+			return foundType;
+		} else { // Reinforcement type is global, and has been found
+			return foundType;
+		}
 	}
 
-	public void register(ReinforcementType type) {
-		typesByItem.put(type.getItem(), type);
+	public boolean register(ReinforcementType type) {
 		typesById.put(type.getID(), type);
+
+		if (type.getAllowedWorlds().isEmpty()) { // Registering a global reinforcement
+			if (localTypesByItem.get(type.getItem()) != null) {
+				// Problem because there is already a local reinforcement for the item type
+				return false;
+			}
+
+			globalTypesByItem.put(type.getItem(), type); // Types with no allowed worlds are global and able to be used everywhere
+
+			return true;
+		} else { // Registering a local reinforcement
+			if (globalTypesByItem.get(type.getItem()) != null) {
+				// Problem because there is already a global reinforcement for the item type
+				return false;
+			}
+
+			// At this point we have verified there is not already a global reinforcement, so the local reinforcement can go ahead
+
+			for (String allowedWorld : type.getAllowedWorlds()) { // For all the allowed worlds
+
+				if (localTypesByItem.computeIfAbsent(type.getItem(), k -> new HashMap<>()) // Put the item in the map and create a sub-map if it doesn't already exist, if so there should not be any conflicting local-items
+						.put(allowedWorld, type) != null) { // Put the allowed world, if a value is returned, there was previously something associated with the world, therefore there are two local reinforcements attempting to exist locally in a world
+					return false;
+				}
+			}
+
+			return true;
+		}
 	}
 
 }

--- a/paper/src/main/java/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementTypeManager.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementTypeManager.java
@@ -2,17 +2,18 @@ package vg.civcraft.mc.citadel.reinforcementtypes;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import org.bukkit.inventory.ItemStack;
 
 public class ReinforcementTypeManager {
 
-	private Map<ItemStack, ReinforcementType> typesByItem;
 	private Map<Short, ReinforcementType> typesById;
+	private Map<String, Map<ItemStack, ReinforcementType>> typesByWorld;
 
 	public ReinforcementTypeManager() {
-		typesByItem = new HashMap<>();
+		typesByWorld = new HashMap<>();
 		typesById = new TreeMap<>();
 	}
 
@@ -24,14 +25,15 @@ public class ReinforcementTypeManager {
 		return typesById.get(id);
 	}
 
-	public ReinforcementType getByItemStack(ItemStack is) {
+	public ReinforcementType getByItemStackAndWorld(ItemStack is, String worldName)
+	{
 		ItemStack copy = is.clone();
 		copy.setAmount(1);
-		return typesByItem.get(copy);
+		return typesByWorld.getOrDefault(worldName, new HashMap<>()).get(copy);
 	}
 
 	public void register(ReinforcementType type) {
-		typesByItem.put(type.getItem(), type);
+		type.getAllowedWorlds().forEach(allowedWorld -> typesByWorld.computeIfAbsent(allowedWorld, k -> new HashMap<>()).put(type.getItem(), type));
 		typesById.put(type.getID(), type);
 	}
 

--- a/paper/src/main/java/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementTypeManager.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementTypeManager.java
@@ -2,18 +2,17 @@ package vg.civcraft.mc.citadel.reinforcementtypes;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import org.bukkit.inventory.ItemStack;
 
 public class ReinforcementTypeManager {
 
+	private Map<ItemStack, ReinforcementType> typesByItem;
 	private Map<Short, ReinforcementType> typesById;
-	private Map<String, Map<ItemStack, ReinforcementType>> typesByWorld;
 
 	public ReinforcementTypeManager() {
-		typesByWorld = new HashMap<>();
+		typesByItem = new HashMap<>();
 		typesById = new TreeMap<>();
 	}
 
@@ -25,15 +24,14 @@ public class ReinforcementTypeManager {
 		return typesById.get(id);
 	}
 
-	public ReinforcementType getByItemStackAndWorld(ItemStack is, String worldName)
-	{
+	public ReinforcementType getByItemStack(ItemStack is) {
 		ItemStack copy = is.clone();
 		copy.setAmount(1);
-		return typesByWorld.getOrDefault(worldName, new HashMap<>()).get(copy);
+		return typesByItem.get(copy);
 	}
 
 	public void register(ReinforcementType type) {
-		type.getAllowedWorlds().forEach(allowedWorld -> typesByWorld.computeIfAbsent(allowedWorld, k -> new HashMap<>()).put(type.getItem(), type));
+		typesByItem.put(type.getItem(), type);
 		typesById.put(type.getID(), type);
 	}
 


### PR DESCRIPTION
Adds world-whitelist support for reinforcements, as well as support and logic for multiple reinforcements of the same type, but in different whitelisted worlds.