### PR TITLE
Improve moss spreading check logic

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -571,12 +571,16 @@ public class BlockListener implements Listener {
 		Iterator<BlockState> iterator = event.getBlocks().iterator();
 		Block dispenser = mossSpreadingDispensers.remove(event.getBlock());
 		Reinforcement dispenserRein = dispenser == null ? null
-				: Citadel.getInstance().getReinforcementManager().getReinforcement(dispenser);
+				: Citadel.getInstance()
+					.getReinforcementManager()
+					.getReinforcement(dispenser);
 		Group dispenserGroup = dispenserRein == null ? null :
 				dispenserRein.getGroup();
 		while (iterator.hasNext()) {
 			BlockState block = iterator.next();
-			Reinforcement reinforcement = Citadel.getInstance().getReinforcementManager().getReinforcement(block.getBlock());
+			Reinforcement reinforcement = Citadel.getInstance()
+				.getReinforcementManager()
+				.getReinforcement(block.getBlock());
 			if (reinforcement == null) {
 				continue;
 			}

--- a/paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -45,6 +45,8 @@ import vg.civcraft.mc.civmodcore.inventory.items.MoreTags;
 import vg.civcraft.mc.civmodcore.utilities.DoubleInteractFixer;
 import vg.civcraft.mc.civmodcore.world.WorldUtils;
 
+import java.util.Iterator;
+
 public class BlockListener implements Listener {
 
 	private static final Material matfire = Material.FIRE;
@@ -561,36 +563,18 @@ public class BlockListener implements Listener {
 
 	@EventHandler(ignoreCancelled = true)
 	public void onMossSpread(BlockFertilizeEvent event) {
-		for (BlockState block : event.getBlocks()) {
+		Player player = event.getPlayer();
+		Iterator<BlockState> iterator = event.getBlocks().iterator();
+		while (iterator.hasNext()) {
+			BlockState block = iterator.next();
 			Reinforcement reinforcement = Citadel.getInstance().getReinforcementManager().getReinforcement(block.getBlock());
 			if (reinforcement == null) {
 				continue;
 			}
-			Player player = event.getPlayer();
-			if (player == null) {
+			if (player != null && reinforcement.hasPermission(player, CitadelPermissionHandler.getCrops())) {
 				continue;
 			}
-			if (reinforcement.hasPermission(event.getPlayer(), CitadelPermissionHandler.getCrops())) {
-				continue;
-			}
-			event.getPlayer().sendMessage(Component.text("You can't do that while their are reinforced blocks around!").color(NamedTextColor.RED));
-			event.setCancelled(true);
+			iterator.remove();
 		}
-	}
-
-	@EventHandler(ignoreCancelled = true)
-	public void onDispenserGrowMoss(BlockDispenseEvent event){
-		Block dispenserBlock = event.getBlock();
-		ItemStack bonemeal = event.getItem();
-		Dispenser dispenser = (Dispenser) event.getBlock().getBlockData();
-
-		if (bonemeal.getType() != Material.BONE_MEAL) {
-			return;
-		}
-		Block moss = dispenserBlock.getRelative(dispenser.getFacing());
-		if (moss.getType() != Material.MOSS_BLOCK) {
-			return;
-		}
-		event.setCancelled(true);
 	}
 }


### PR DESCRIPTION
This improves the moss spreading checks by revamping how the spread blocks are disabled, and allowing dispensers to spread moss to same-group and unreinforced blocks.

Changes:
- Allow dispensers to spread moss either if the dispenser is in the same group as the block, or if the block is unreinforced. Fixes #12 
- Instead of preventing the entire spread when there is a reinforced block nearby, the spreading will simply not spread to inaccessible reinforced blocks, and will only spread to blocks the player has access to. 