### PR TITLE
Fix isAuthorizedPlayerNear distance

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/citadel/listener/RedstoneListener.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/listener/RedstoneListener.java
@@ -44,14 +44,12 @@ public class RedstoneListener implements Listener {
 		if (reinLocation.getWorld() == null) {
 			return false;
 		}
-
-		// distance is radius, not diameter
-		double diameter = distance * 2;
-		Collection<Entity> entities = reinLocation.getWorld().getNearbyEntities(reinLocation, diameter, diameter,
-				diameter,
+		// distance is radius
+		Collection<Entity> entities = reinLocation.getWorld().getNearbyEntities(reinLocation, distance, distance,
+				distance,
 				e -> e instanceof Player && !e.isDead()
 						&& reinforcement.hasPermission(e.getUniqueId(), CitadelPermissionHandler.getDoors())
-						&& e.getLocation().distanceSquared(reinLocation) <= diameter * diameter);
+						&& e.getLocation().distanceSquared(reinLocation) <= distance * distance);
 		return !entities.isEmpty();
 	}
 


### PR DESCRIPTION
Currently, it inputs the diameter of the distance into getNearbyEntities, effectively doubling the radius that it's checking. getNearbyEntities takes in 3 radii, not diameters. 
This change makes isAuthorizedPlayerNear input the radius into getNearbyEntities instead of the diameter.