### PR TITLE
Add patch-mode feedback

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/PatchState.java
+++ b/paper/src/main/java/vg/civcraft/mc/citadel/playerstate/PatchState.java
@@ -78,6 +78,18 @@ public class PatchState extends AbstractPlayerState {
 				return;
 			}
 		}
+
+		CitadelUtility.sendAndLog(
+				player,
+				ChatColor.GOLD, "Patching "
+						+ ChatColor.AQUA + rein.getType().getName()
+						+ ChatColor.GOLD + " reinforcement owned by "
+						+ ChatColor.LIGHT_PURPLE + rein.getGroup().getName()
+						+ ChatColor.GOLD + " from "
+						+ ModeListener.formatHealth(rein),
+				e.getClickedBlock().getLocation()
+		);
+
 		rein.setHealth(rein.getType().getHealth());
 		rein.resetCreationTime();
 	}


### PR DESCRIPTION
Patch mode currently doesn't tell you when you've successfully patched a reinforcement. Instead, you get an earlier output on the next tick with the now full health.